### PR TITLE
Update KSCrash to 2.1.1 to support using bazel rules for Swift Package Manager

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kstenerud/KSCrash",
       "state" : {
-        "revision" : "b87a3ef5b0b84e2a34a546b9836813756cd362a9",
-        "version" : "2.0.0"
+        "revision" : "2aec11b25784a786c29de0f7a78d837b495794d7",
+        "version" : "2.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     dependencies: [
         .package(
              url: "https://github.com/kstenerud/KSCrash",
-             .upToNextMinor(from: "2.0.0")
+             .upToNextMinor(from: "2.1.1")
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",


### PR DESCRIPTION
We could not use [rules_swift_package_manager](https://github.com/cgrindel/rules_swift_package_manager) to build with [bazel](https://bazel.build) see https://github.com/cgrindel/rules_swift_package_manager/issues/1279 and https://github.com/kstenerud/KSCrash/pull/627